### PR TITLE
fix: typos in `sidebar.md` and `widgets.md`

### DIFF
--- a/docs/config/sidebar.md
+++ b/docs/config/sidebar.md
@@ -29,7 +29,7 @@ Subtitle displayed below the site title.
 
 Configurations related with avatar.
 
-### avatar.enable
+### avatar.enabled
 
 - Type: `bool`
 - Default: `true`

--- a/docs/config/widgets.md
+++ b/docs/config/widgets.md
@@ -4,7 +4,7 @@ Widgets are placed at right sidebar of the blog. They are used to display some i
 
 You can configure which widgets to display and their order in the homepage and post page.
 
-`widget.homepage` and `widget.page` are arrays of maps. Each map contains two keys: `type` and `params`. `type` is the name of the widget. `params` is the configuration of the widget.
+`widgets.homepage` and `widgets.page` are arrays of maps. Each map contains two keys: `type` and `params`. `type` is the name of the widget. `params` is the configuration of the widget.
 
 ## Available widgets
 


### PR DESCRIPTION
1. Fix `avatar.enable` to `avatar.enabled` in `sidebar.md`.
2. Fix `widget` to `widgets` in `widgets.md`.